### PR TITLE
Ruta de ordenes no se ve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "carrduci-sys-gui",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carrduci-sys-gui",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "GUI Descktop CARRDUCIsys",
   "scripts": {
     "ng": "ng",

--- a/src/app/pages/gestionDeFolios/ordenes/ordenes-detalle.component.css
+++ b/src/app/pages/gestionDeFolios/ordenes/ordenes-detalle.component.css
@@ -1,0 +1,31 @@
+@media print {
+  @page {
+    margin: 5mm;
+
+    size: 66 279mm;
+  }
+
+  .orden {
+    width: 100%;
+    max-height: 70mm;
+    min-height: 70mm;
+    height: 70mm;
+
+    position: relative;
+
+    page-break-inside: avoid;
+    -webkit-region-break-inside: avoid;
+    margin-bottom: 4mm;
+  }
+
+  .orden-footer {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  }
+  .salto-de-pagina {
+    position: relative;
+    page-break-inside: avoid;
+    page-break-after: always;
+  }
+}

--- a/src/app/pages/gestionDeFolios/ordenes/ordenes-detalle.component.html
+++ b/src/app/pages/gestionDeFolios/ordenes/ordenes-detalle.component.html
@@ -64,6 +64,11 @@
           href="javascript:void(0)"
           role="button"
         >
+          <i
+            *ngIf="keys('cargando').includes('pool')"
+            class="fas fa-sync fa-spin-fast"
+          ></i>
+
           <i class="fas fa-print"></i
         ></a>
       </div>
@@ -90,10 +95,8 @@
     <div class="orden-footer">
       <hr class="thin" />
       <div class="font-weight-bold" style="font-size: 6pt;">
-        <ng-container
-          *ngFor="let trayecto of orden.trayectoNormal; let i = index"
-        >
-          {{ trayecto.departamento.nombre }}
+        <ng-container *ngFor="let ruta of orden.ruta; let i = index">
+          {{ ruta.departamento }}
           <span *ngIf="i + 1 != orden.trayectoNormal.length">
             >
           </span>

--- a/src/app/pages/gestionDeFolios/ordenes/ordenes-detalle.component.ts
+++ b/src/app/pages/gestionDeFolios/ordenes/ordenes-detalle.component.ts
@@ -3,16 +3,23 @@ import { Folio } from 'src/app/models/folio.models'
 import { FolioLinea } from '../../../models/folioLinea.models'
 import { Orden } from 'src/app/models/orden.models'
 import { ImpresionService } from '../../../services/impresion.service'
+import { DepartamentoService } from '../../../services/departamento/departamento.service'
 
 declare var $: any
 
 @Component({
   selector: 'app-ordenes-detalle',
   templateUrl: './ordenes-detalle.component.html',
-  styles: []
+  styleUrls: ['./ordenes-detalle.component.css']
 })
 export class OrdenesDetalleComponent implements OnInit {
-  constructor(public impresionService: ImpresionService) {}
+  constructor(
+    public impresionService: ImpresionService,
+    public departamentoService: DepartamentoService
+  ) {}
+
+  cargando = {}
+  keys = Object.keys
 
   @Input() folio: Folio
   @Input() linea: FolioLinea
@@ -40,8 +47,24 @@ export class OrdenesDetalleComponent implements OnInit {
   }
 
   imprimir() {
-    $('.modal').modal('hide')
+    if (this.departamentoService.pool.length === 0) {
+      this.departamentoService.findAllPoolObservable().subscribe(() => {
+        this.orden.ruta.forEach(
+          r =>
+            (r.departamento = this.departamentoService.pool.find(
+              d => d._id === r.idDepartamento
+            ).nombre)
+        )
 
+        this.print()
+      })
+    } else {
+      this.print()
+    }
+  }
+
+  private print() {
+    $('.modal').modal('hide')
     setTimeout(() => {
       this.impresionService
         .ordenes([this.orden._id])

--- a/src/app/pages/gestionDeFolios/seguimiento/folios-seguimiento/folios-seguimiento.component.ts
+++ b/src/app/pages/gestionDeFolios/seguimiento/folios-seguimiento/folios-seguimiento.component.ts
@@ -5,6 +5,7 @@ import { FolioNewService } from 'src/app/services/folio/folio-new.service'
 import { iPedidosConsulta } from '../../../../services/folio/folio-new.service'
 import { Paginacion } from '../../../../utils/paginacion.util'
 import { ImpresionService } from '../../../../services/impresion.service'
+import { DepartamentoService } from '../../../../services/departamento/departamento.service'
 
 @Component({
   selector: 'app-folios-seguimiento',
@@ -21,7 +22,8 @@ export class FoliosSeguimientoComponent implements OnInit {
 
   constructor(
     public folioService: FolioNewService,
-    private impresionService: ImpresionService
+    private impresionService: ImpresionService,
+    private departamentoService: DepartamentoService
   ) {}
 
   ngOnInit() {
@@ -94,8 +96,19 @@ export class FoliosSeguimientoComponent implements OnInit {
     })
   }
 
-  imprimirFolio(idFolio: string, idPedido: string) {
+  async imprimirFolio(idFolio: string, idPedido: string) {
+    if (this.departamentoService.pool.length === 0)
+      await this.departamentoService.findAllPoolObservable().toPromise()
+
     this.folioService.findById(idFolio).subscribe(folio => {
+      folio.folioLineas
+        .find(x => x._id === idPedido)
+        .ordenes.forEach(x => {
+          x.ruta.forEach(r =>
+            this.departamentoService.popularRutaConDepartamento(r)
+          )
+        })
+
       let ordenes = folio.folioLineas
         .find(x => x._id === idPedido)
         .ordenes.map(x => x._id)

--- a/src/app/services/departamento/departamento.service.ts
+++ b/src/app/services/departamento/departamento.service.ts
@@ -12,6 +12,7 @@ import { UsuarioService } from '../usuario/usuario.service'
 import { throwError, Observable } from 'rxjs'
 import { Paginacion } from 'src/app/utils/paginacion.util'
 import { map, catchError } from 'rxjs/operators'
+import { Ruta } from '../../models/orden.models'
 
 @Injectable({
   providedIn: 'root'
@@ -156,5 +157,19 @@ export class DepartamentoService {
     this.findAll(new Paginacion(100, 0, 1, 'nombre')).subscribe(
       depa => (this.pool = depa)
     )
+  }
+
+  findAllPoolObservable(): Observable<Departamento[]> {
+    return this.findAll(new Paginacion(100, 0, 1, 'nombre')).pipe(
+      map(x => {
+        this.pool = x
+        return x
+      })
+    )
+  }
+
+  popularRutaConDepartamento(ruta: Ruta) {
+    let departamento = this.pool.find(x => x._id === ruta.idDepartamento)
+    ruta.departamento = departamento.nombre
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -112,35 +112,7 @@ transform: translateX(-50%);
     display: inline !important;
     position: absolute !important;
   }
-  @page {
-    margin: 5mm;
-
-    size: 66 279mm;
-  }
-
-  .orden {
-    width: 100%;
-    max-height: 70mm;
-    min-height: 70mm;
-    height: 70mm;
-
-    position: relative;
-
-    page-break-inside: avoid;
-    -webkit-region-break-inside: avoid;
-    margin-bottom: 4mm;
-  }
-
-  .orden-footer {
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-  }
-  .salto-de-pagina {
-    position: relative;
-    page-break-inside: avoid;
-    page-break-after: always;
-  }
+ 
 }
 
 hr {


### PR DESCRIPTION
No se autopopulaban los departamentos de las rutas y se utilizaba el trayecto en vez de el nuevo rutas. 